### PR TITLE
Babel Loader: Exclude node_modules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
 	},
 	module: {
 		loaders: [{
+			exclude: /node_modules/,
 			loader: "babel-loader",
 			query: {
 				presets: ["es2015"],


### PR DESCRIPTION
This has two effects:
1. The compilation is a lot faster
2. The compilation works with `npm link`ed dependencies

Source: https://github.com/babel/babel-loader#usage

I'm not entirely sure why, though. I will investigate that a little further, but I'm happy about any hints :smile: 
